### PR TITLE
Fix deploy tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} #TODO(berry): fix on git labels multiple tags
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
@@ -178,7 +178,6 @@ jobs:
           echo "labels: ${{ steps.meta.outputs.labels }}"
           echo "annotations: ${{ steps.meta.outputs.annotations }}"
           echo "hash: ${{ steps.get_commit_hash.outputs.commit_hash }}"
-
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -254,9 +253,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          images: "" # make empty to get the correct tag
+
+      - name: print metadata
+        run: |
+          echo "tags: ${{ steps.meta.outputs.tags }}"
 
       - name: Trigger deployment
         run: |


### PR DESCRIPTION
# Description

Deployment currently uses the full docker pull tag to use as tag. i only want to use the base. this could fix the issue

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
