### PR TITLE
Fix tag deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,20 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
 
+      - name: Extract metadata for Docker
+        id: meta2
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} #TODO(berry): fix on git labels multiple tags
+          flavor: |
+            latest=false
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+
       - name: Run Trivy SBOM
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ steps.meta.outputs.tags }}
+          image-ref: ${{ steps.meta2.outputs.tags }}
           scan-type: image
           exit-code: 0
           format: 'cyclonedx'
@@ -223,7 +233,7 @@ jobs:
       - name: Run Trivy license scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ steps.meta.outputs.tags }}
+          image-ref: ${{ steps.meta2.outputs.tags }}
           scan-type: image
           scanners: 'license'
           exit-code: 0
@@ -254,6 +264,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: "" # make empty to get the correct tag
+          flavor: |
+            latest=false
 
       - name: print metadata
         run: |


### PR DESCRIPTION
# Description

when using git tags we get an array returned with 2 tags. this breaks the cd and code scanning. Removing latest from the list might solve the issue. 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
