### PR TITLE
77 visually duplicate task bug with test

### DIFF
--- a/script/test
+++ b/script/test
@@ -4,7 +4,7 @@ set -e
 set -x
 
 
-if ! coverage run -m pytest "$@" ; then
+if ! poetry run coverage run -m pytest "$@" ; then
     echo "Test failed"
     exit 1
 fi

--- a/tad/site/static/js/tad.js
+++ b/tad/site/static/js/tad.js
@@ -1,21 +1,29 @@
 window.onload = function () {
 
+  // TODO (robbert): we need (better) event handling and displaying of server errors
+  document.body.addEventListener('htmx:sendError', function(evt) {
+    document.getElementById("errorContainer").innerHTML = "<h1>Placeholder: Error while connecting to server</h1";
+  });
+
   const columns = document.getElementsByClassName("progress_cards_container");
   for (let i = 0; i < columns.length; i++) {
     new Sortable(columns[i], { //NOSONAR
       group: 'shared', // set both lists to same group
       animation: 150,
       onEnd: function (evt) {
-        let previousSiblingId = evt.item.previousElementSibling ? evt.item.previousElementSibling.getAttribute("data-id") : "-1";
-        let nextSiblingId = evt.item.nextElementSibling ? evt.item.nextElementSibling.getAttribute("data-id") : "-1";
-        let targetId = "#" + evt.item.getAttribute("id");
-        let form = document.getElementById("cardMovedForm");
-        document.getElementsByName("taskId")[0].value = evt.item.getAttribute("data-id");
-        document.getElementsByName("statusId")[0].value = evt.to.getAttribute("data-id");
-        document.getElementsByName("previousSiblingId")[0].value = previousSiblingId;
-        document.getElementsByName("nextSiblingId")[0].value = nextSiblingId;
-        form.setAttribute("hx-target", targetId);
-        htmx.trigger("#cardMovedForm", "cardmoved");
+        if (evt.oldIndex !== evt.newIndex || evt.from !== evt.to) {
+          let previousSiblingId = evt.item.previousElementSibling ? evt.item.previousElementSibling.getAttribute("data-id") : "-1";
+          let nextSiblingId = evt.item.nextElementSibling ? evt.item.nextElementSibling.getAttribute("data-id") : "-1";
+          let targetId = "#" + evt.item.getAttribute("data-target-id");
+          let toStatusId = evt.to.getAttribute("data-id");
+          let form = document.getElementById("cardMovedForm");
+          document.getElementsByName("taskId")[0].value = evt.item.getAttribute("data-id");
+          document.getElementsByName("statusId")[0].value = toStatusId;
+          document.getElementsByName("previousSiblingId")[0].value = previousSiblingId;
+          document.getElementsByName("nextSiblingId")[0].value = nextSiblingId;
+          form.setAttribute("hx-target", targetId);
+          htmx.trigger("#cardMovedForm", "cardmoved");
+        }
       }
     });
   }

--- a/tad/site/templates/macros/render.html.jinja
+++ b/tad/site/templates/macros/render.html.jinja
@@ -1,14 +1,28 @@
-{% macro render_task_card(task) -%}
-    {% include "task.html.jinja" %}
-{%- endmacro -%}
-
 {% macro column(status, translations, tasks_service) -%}
     <div class="col span_1_of_4">
         <h3 class="text-center-horizontal margin-bottom--small">{{ translations[status.name] }}</h3>
         <div class="progress_cards_container sortable" data-id="{{ status.id }}" id="column-{{ status.id }}">
             {% for task in tasks_service.get_tasks(status.id) %}
-                {{ render_task_card(task) }}
+                {{ render_task_card_full(task) }}
             {% endfor %}
         </div>
     </div>
 {% endmacro -%}
+
+{% macro render_task_card_full(task) -%}
+<div class="progress_card_container" data-target-id="card-content-{{ task.id }}" id="card-container-{{ task.id }}" data-id="{{ task.id }}">
+    {{ render_task_card_content(task) }}
+</div>
+{% endmacro %}
+
+{% macro render_task_card_content(task) -%}
+<div id="card-content-{{ task.id }}" data-id="{{ task.id }}">
+    <h4 class="margin-bottom--extra-small">{{ task.title }}</h4>
+    <div>{{ task.description }}</div>
+    {% if task.user_id %}
+        <div class="progress_card_assignees_container">
+            <img class="progress_card_assignees_image" src="/static/images/img_avatar.png" alt="Assigned to Avatar"/>
+        </div>
+    {% endif %}
+</div>
+{% endmacro %}

--- a/tad/site/templates/task.html.jinja
+++ b/tad/site/templates/task.html.jinja
@@ -1,9 +1,2 @@
-<div class="progress_card_container" id="card-{{ task.id }}" data-id="{{ task.id }}">
-    <h4 class="margin-bottom--extra-small">{{ task.title }}</h4>
-    <div>{{ task.description }}</div>
-    {% if task.user_id %}
-        <div class="progress_card_assignees_container">
-            <img class="progress_card_assignees_image" src="/static/images/img_avatar.png" alt="Assigned to Avatar"/>
-        </div>
-    {% endif %}
-</div>
+{% import 'macros/render.html.jinja' as render %}
+{{ render.render_task_card_content(task) }}

--- a/tests/api/routes/test_status.py
+++ b/tests/api/routes/test_status.py
@@ -14,7 +14,7 @@ def test_post_move_task(client: TestClient, db: DatabaseTestUtils) -> None:
     response = client.patch("/tasks/", json=move_task.model_dump(by_alias=True))
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
-    assert b'class="progress_card_container"' in response.content
+    assert b'id="card-content-' in response.content
 
 
 def test_post_move_task_no_siblings(client: TestClient, db: DatabaseTestUtils) -> None:
@@ -26,4 +26,4 @@ def test_post_move_task_no_siblings(client: TestClient, db: DatabaseTestUtils) -
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
-    assert b'class="progress_card_container"' in response.content
+    assert b'id="card-content-' in response.content

--- a/tests/api/routes/test_tasks_move.py
+++ b/tests/api/routes/test_tasks_move.py
@@ -16,7 +16,7 @@ def test_post_task_move(client: TestClient, db: DatabaseTestUtils) -> None:
     assert b'id="card-content-1"' in response.content
 
 
-def test_task_move_error(client: TestClient) -> None:
+def test_task_move_error(client: TestClient, db: DatabaseTestUtils) -> None:
     response = client.patch(
         "/tasks/", json={"taskId": "1", "statusId": "1", "previousSiblingId": "2", "nextSiblingId": "-1"}
     )

--- a/tests/api/routes/test_tasks_move.py
+++ b/tests/api/routes/test_tasks_move.py
@@ -13,7 +13,7 @@ def test_post_task_move(client: TestClient, db: DatabaseTestUtils) -> None:
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
-    assert b'id="card-1"' in response.content
+    assert b'id="card-content-1"' in response.content
 
 
 def test_task_move_error(client: TestClient) -> None:

--- a/tests/database_test_utils.py
+++ b/tests/database_test_utils.py
@@ -11,12 +11,7 @@ class DatabaseTestUtils:
         self.models: list[BaseModel] = []
 
     def __del__(self):
-        for model in self.models:
-            try:
-                self.session.delete(model)
-                self.session.commit()
-            except Exception:  # noqa: S110
-                pass
+        pass
 
     def given(self, models: list[BaseModel]) -> None:
         self.models.extend(models)

--- a/tests/e2e/test_move_task.py
+++ b/tests/e2e/test_move_task.py
@@ -40,9 +40,9 @@ def test_move_task_order_in_same_column(browser: Page, db: DatabaseTestUtils) ->
     all_status = [*all_statusses()]
     db.given([*all_status])
 
-    task1 = default_task(status_id=all_status[0].id)
-    task2 = default_task(status_id=all_status[0].id)
-    task3 = default_task(status_id=all_status[0].id)
+    task1 = default_task(title="Task 1", status_id=all_status[0].id, sort_order=10)
+    task2 = default_task(title="Task 2", status_id=all_status[0].id, sort_order=20)
+    task3 = default_task(title="Task 3", status_id=all_status[0].id, sort_order=30)
 
     db.given([task1, task2, task3])
 
@@ -51,17 +51,16 @@ def test_move_task_order_in_same_column(browser: Page, db: DatabaseTestUtils) ->
     expect(browser.locator("#column-1 #card-1")).to_be_visible()
     expect(browser.locator("#column-1")).to_be_visible()
 
-    # todo (robbert) code below doesn't do what it should do, card is not moved
-    task = browser.locator("#card-1")
-    task.hover()
+    browser.locator("#card-1").hover()
     browser.mouse.down()
-    browser.mouse.move(0, 50)
+    # todo (robbert): find out who browser.mouse.move() is not working, we use a locator now instead
+    browser.locator("#card-container-2").hover()
+    browser.screenshot(full_page=True, path="screenshot2.png")
     browser.mouse.up()
-    # https://playwright.dev/docs/input
+
     browser.reload()
 
     tasks_in_column = browser.locator("#column-1").locator(".progress_card_container").all()
-    # todo (robbert) this order should be changed if code above works correctly
-    expect(tasks_in_column[0]).to_have_id("card-1")
-    expect(tasks_in_column[1]).to_have_id("card-2")
+    expect(tasks_in_column[0]).to_have_id("card-2")
+    expect(tasks_in_column[1]).to_have_id("card-1")
     expect(tasks_in_column[2]).to_have_id("card-3")

--- a/tests/e2e/test_move_task.py
+++ b/tests/e2e/test_move_task.py
@@ -17,17 +17,17 @@ def test_move_task_to_column(browser: Page, db: DatabaseTestUtils) -> None:
 
     browser.goto("/pages/")
 
-    expect(browser.locator("#column-1 #card-1")).to_be_visible()
+    expect(browser.locator("#column-1 #card-container-1")).to_be_visible()
     expect(browser.locator("#column-3")).to_be_visible()
 
     # todo (Robbert) action below is performed twice, because once does not work, we need find out why and fix it
-    browser.locator("#card-1").drag_to(browser.locator("#column-3"))
-    browser.locator("#card-1").drag_to(browser.locator("#column-3"))
+    browser.locator("#card-container-1").drag_to(browser.locator("#column-3"))
+    browser.locator("#card-container-1").drag_to(browser.locator("#column-3"))
 
     browser.reload()
 
-    card = browser.locator("#column-3 #card-1")
-    expect(card).to_have_id("card-1")
+    card = browser.locator("#column-3 #card-container-1")
+    expect(card).to_have_id("card-container-1")
     expect(card).to_be_visible()
 
 
@@ -48,19 +48,19 @@ def test_move_task_order_in_same_column(browser: Page, db: DatabaseTestUtils) ->
 
     browser.goto("/pages/")
 
-    expect(browser.locator("#column-1 #card-1")).to_be_visible()
+    expect(browser.locator("#column-1 #card-container-1")).to_be_visible()
     expect(browser.locator("#column-1")).to_be_visible()
 
-    browser.locator("#card-1").hover()
+    browser.locator("#card-container-1").hover()
     browser.mouse.down()
     # todo (robbert): find out who browser.mouse.move() is not working, we use a locator now instead
     browser.locator("#card-container-2").hover()
-    browser.screenshot(full_page=True, path="screenshot2.png")
     browser.mouse.up()
 
     browser.reload()
 
     tasks_in_column = browser.locator("#column-1").locator(".progress_card_container").all()
-    expect(tasks_in_column[0]).to_have_id("card-2")
-    expect(tasks_in_column[1]).to_have_id("card-1")
-    expect(tasks_in_column[2]).to_have_id("card-3")
+    # todo (robbert) this order should be changed if code above works correctly
+    expect(tasks_in_column[0]).to_have_id("card-container-2")
+    expect(tasks_in_column[1]).to_have_id("card-container-1")
+    expect(tasks_in_column[2]).to_have_id("card-container-3")

--- a/tests/regression/e2e/test_duplicate_task_bug.py
+++ b/tests/regression/e2e/test_duplicate_task_bug.py
@@ -1,0 +1,41 @@
+from time import sleep
+
+from playwright.sync_api import Page, expect
+from tests.constants import all_statusses, default_task
+from tests.database_test_utils import DatabaseTestUtils
+
+
+def test_duplicate_task(browser: Page, db: DatabaseTestUtils) -> None:
+    """
+    When a task is dragged while being updated, an error occurred in the browser
+    resulting in visual duplicates of the card being dragged.
+    This test captured that behaviour.
+    """
+    error_logs: list[str] = []
+    browser.on("console", lambda msg: error_logs.append(msg.text))
+
+    all_status = all_statusses()
+    db.given([*all_status])
+    db.given([default_task(status_id=all_status[0].id)])
+
+    browser.goto("/pages/")
+
+    expect(browser.locator("#column-1 #card-1")).to_be_visible()
+    expect(browser.locator("#column-3")).to_be_visible()
+
+    browser.evaluate('document.getElementById("cardMovedForm").setAttribute("hx-target","#card-1")')
+    browser.evaluate('document.getElementsByName("taskId")[0].value = 1')
+    browser.evaluate('document.getElementsByName("statusId")[0].value = 2')
+    browser.evaluate('document.getElementsByName("previousSiblingId")[0].value = -1')
+    browser.evaluate('document.getElementsByName("nextSiblingId")[0].value = -1')
+
+    browser.locator("#card-1").hover()
+    browser.mouse.down()
+    browser.locator("#column-3").hover()
+    browser.evaluate('htmx.trigger("#cardMovedForm", "cardmoved")')
+    sleep(1)
+    browser.mouse.up()
+    cards = browser.locator(".progress_card_container").all()
+    assert len(cards) == 2
+
+    expect(browser.locator(".header_logo_container")).to_be_visible()

--- a/tests/regression/e2e/test_duplicate_task_bug.py
+++ b/tests/regression/e2e/test_duplicate_task_bug.py
@@ -11,8 +11,6 @@ def test_duplicate_task(browser: Page, db: DatabaseTestUtils) -> None:
     resulting in visual duplicates of the card being dragged.
     This test captured that behaviour.
     """
-    error_logs: list[str] = []
-    browser.on("console", lambda msg: error_logs.append(msg.text))
 
     all_status = all_statusses()
     db.given([*all_status])
@@ -20,22 +18,20 @@ def test_duplicate_task(browser: Page, db: DatabaseTestUtils) -> None:
 
     browser.goto("/pages/")
 
-    expect(browser.locator("#column-1 #card-1")).to_be_visible()
+    expect(browser.locator("#column-1 #card-container-1")).to_be_visible()
     expect(browser.locator("#column-3")).to_be_visible()
 
-    browser.evaluate('document.getElementById("cardMovedForm").setAttribute("hx-target","#card-1")')
+    browser.evaluate('document.getElementById("cardMovedForm").setAttribute("hx-target","#card-content-1")')
     browser.evaluate('document.getElementsByName("taskId")[0].value = 1')
     browser.evaluate('document.getElementsByName("statusId")[0].value = 2')
     browser.evaluate('document.getElementsByName("previousSiblingId")[0].value = -1')
     browser.evaluate('document.getElementsByName("nextSiblingId")[0].value = -1')
 
-    browser.locator("#card-1").hover()
+    browser.locator("#card-container-1").hover()
     browser.mouse.down()
     browser.locator("#column-3").hover()
     browser.evaluate('htmx.trigger("#cardMovedForm", "cardmoved")')
     sleep(1)
     browser.mouse.up()
     cards = browser.locator(".progress_card_container").all()
-    assert len(cards) == 2
-
-    expect(browser.locator(".header_logo_container")).to_be_visible()
+    assert len(cards) == 1

--- a/tests/site/static/templates/test_task_template.py
+++ b/tests/site/static/templates/test_task_template.py
@@ -9,9 +9,9 @@ def test_template_rendering():
     task = Task(id=1, title="Test Task", description="Test Description", sort_order=1)
     result = env.get_template(name="task.html.jinja").render(task=task)
     expected_result = """
-    <div class="progress_card_container" id="card-1" data-id="1">
-        <h4 class="margin-bottom--extra-small">Test Task</h4>
-        <div>Test Description</div>
+    <div id="card-content-1" data-id="1">
+      <h4 class="margin-bottom--extra-small">Test Task</h4>
+      <div>Test Description</div>
     </div>
     """
     # todo (robbert) there is probably a better way to clean results than replacing newlines and spaces


### PR DESCRIPTION
# Description

This PR fixed the issue where dragging a task while updating could result in visually duplicate tasks. The fix includes a regression test to prove the problem has been solved.

The main fix is using a container object and updating the content of the container, instead of updating the container itself. Also we do not update the task when it has not been moved, this is not needed.

Link all GitHub issues fixed by this PR.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X]  I have tested the changes locally and verified that they work as expected.
- [X]  I have followed the project's coding conventions and style guidelines.
- [X]  I have rebased my branch onto the latest commit of the main branch.
- [X]  I have squashed or reorganized my commits into logical units.
- [X]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
